### PR TITLE
Improvements

### DIFF
--- a/lib/reseller.js
+++ b/lib/reseller.js
@@ -10,28 +10,30 @@ var ActiveCampaignReseller = function(api_key, debug) {
 
         locals: {},
 
-        uniqueUsername: function (username, value) {
+        uniqueUsername: function(username, value) {
+            var self = this;
+
             if (value) {
                 if (value === 1) {
                     var nameWith1 = username + '1';
                     ac.api("account/name_check", { 'account': nameWith1 }).then(function(existsWith1) {
                         if (existsWith1.success === 0) {
-                            this.uniqueUsername(username, value++);
+                            self.uniqueUsername(username, value++);
                         } else {
-                            this.locals.accountName = nameWith1;
+                            self.locals.accountName = nameWith1;
                         }
                     }, function() {
                         throw new Error('Slight issue getting account check');
                     });
                 } else {
-                    this.uniqueUsername(username, value++);
+                    self.uniqueUsername(username, value++);
                 }
             } else {
                 ac.api("account/name_check", { 'account': username }).then(function(exists) {
                     if (exists.success === 0) {
-                        this.uniqueUsername(username, 1);
+                        self.uniqueUsername(username, 1);
                     } else {
-                        this.locals.accountName = username;
+                        self.locals.accountName = username;
                     }
                 }, function() {
                     throw new Error('Slight issue getting account check');
@@ -39,7 +41,7 @@ var ActiveCampaignReseller = function(api_key, debug) {
             }
         },
 
-        getPlans:  function(done) {
+        getPlans: function(done) {
             ac.api("account/plans", {}).then(function(plans) {
                 if (plans.success === 1) {
                     done(null, plans);
@@ -64,7 +66,7 @@ var ActiveCampaignReseller = function(api_key, debug) {
         },
 
         isNameTaken: function(accountName, done) {
-            ac.api("account/name_check", { 'account': accountName }).then( function(exists ) {
+            ac.api("account/name_check", { 'account': accountName }).then(function(exists) {
                 if (exists.success === 0) {
                     // already taken
                     done(null, true)
@@ -78,15 +80,17 @@ var ActiveCampaignReseller = function(api_key, debug) {
         },
 
         createNewAccount: function(accountDetails, done) {
-            this.uniqueUsername(accountDetails.name);
+            var self = this;
 
-            setTimeout(function(){
-                accountDetails.name = this.locals.accountName;
+            self.uniqueUsername(accountDetails.name);
+
+            setTimeout(function() {
+                accountDetails.name = self.locals.accountName;
 
                 ac.api("account/add", {
                     account: accountDetails.name,
                     name: accountDetails.customerName,
-                    email:accountDetails.customerEmail,
+                    email: accountDetails.customerEmail,
                     notification: accountDetails.notificationEmail,
                     cname: accountDetails.cname,
                     plan: accountDetails.planId
@@ -103,7 +107,7 @@ var ActiveCampaignReseller = function(api_key, debug) {
         },
 
         getAccountStatus: function(accountName, done) {
-            ac.api("account/status", { 'account': accountName }).then( function(exists ) {
+            ac.api("account/status", { 'account': accountName }).then(function(exists) {
                 if (exists.success === 1) {
                     done(null, exists)
                 } else {

--- a/lib/reseller.js
+++ b/lib/reseller.js
@@ -14,20 +14,18 @@ var ActiveCampaignReseller = function(api_key, debug) {
             var self = this;
 
             if (value) {
-                if (value === 1) {
-                    var nameWith1 = username + '1';
-                    ac.api("account/name_check", { 'account': nameWith1 }).then(function(existsWith1) {
-                        if (existsWith1.success === 0) {
-                            self.uniqueUsername(username, value++);
-                        } else {
-                            self.locals.accountName = nameWith1;
-                        }
-                    }, function() {
-                        throw new Error('Slight issue getting account check');
-                    });
-                } else {
-                    self.uniqueUsername(username, value++);
-                }
+
+                var nameWithVal = username + value;
+                ac.api("account/name_check", { 'account': nameWithVal }).then(function(existsWith1) {
+                    if (existsWith1.success === 0) {
+                        value++;
+                        self.uniqueUsername(username, value);
+                    } else {
+                        self.locals.accountName = nameWithVal;
+                    }
+                }, function() {
+                    throw new Error('Slight issue getting account check');
+                });
             } else {
                 ac.api("account/name_check", { 'account': username }).then(function(exists) {
                     if (exists.success === 0) {

--- a/lib/reseller.js
+++ b/lib/reseller.js
@@ -10,32 +10,37 @@ var ActiveCampaignReseller = function(api_key, debug) {
 
         locals: {},
 
-        uniqueUsername: function(username, value) {
+        uniqueUsername: function(username, value, done) {
             var self = this;
 
-            if (value) {
+            loop(username, value);
 
-                var nameWithVal = username + value;
-                ac.api("account/name_check", { 'account': nameWithVal }).then(function(existsWith1) {
-                    if (existsWith1.success === 0) {
-                        value++;
-                        self.uniqueUsername(username, value);
-                    } else {
-                        self.locals.accountName = nameWithVal;
-                    }
-                }, function() {
-                    throw new Error('Slight issue getting account check');
-                });
-            } else {
-                ac.api("account/name_check", { 'account': username }).then(function(exists) {
-                    if (exists.success === 0) {
-                        self.uniqueUsername(username, 1);
-                    } else {
-                        self.locals.accountName = username;
-                    }
-                }, function() {
-                    throw new Error('Slight issue getting account check');
-                });
+            function loop(username, value) {
+                if (value) {
+                    var nameWithVal = username + value;
+                    ac.api("account/name_check", { 'account': nameWithVal }).then(function(existsWithVal) {
+                        if (existsWithVal.success === 0) {
+                            value++;
+                            loop(username, value);
+                        } else {
+                            self.locals.accountName = nameWithVal;
+                            done();
+                        }
+                    }, function() {
+                        throw new Error('Slight issue getting account check');
+                    });
+                } else {
+                    ac.api("account/name_check", { 'account': username }).then(function(exists) {
+                        if (exists.success === 0) {
+                            loop(username, 1);
+                        } else {
+                            self.locals.accountName = username;
+                            done();
+                        }
+                    }, function() {
+                        throw new Error('Slight issue getting account check');
+                    });
+                }
             }
         },
 
@@ -80,9 +85,8 @@ var ActiveCampaignReseller = function(api_key, debug) {
         createNewAccount: function(accountDetails, done) {
             var self = this;
 
-            self.uniqueUsername(accountDetails.name);
+            self.uniqueUsername(accountDetails.name, null, function() {
 
-            setTimeout(function() {
                 accountDetails.name = self.locals.accountName;
 
                 ac.api("account/add", {
@@ -101,7 +105,7 @@ var ActiveCampaignReseller = function(api_key, debug) {
                 }, function() {
                     throw new Error('Slight issue creating the new account');
                 });
-            }, 3000);
+            });
         },
 
         getAccountStatus: function(accountName, done) {


### PR DESCRIPTION
I noticed a number of issues when using this package to automatically create Active Campaign accounts.
1. Usage of `this` inside `setTimeout`, which has its own context, making `this.locals` undefined.
2. While checking unique names, if `value` is above 1 `uniqueUserName` will just keep looping without checking the name against Active Campaign
3. In the case where there are many names and `uniqueUserName` must do several loops/checks, it can take longer than the timeout.  Changing it to a callback makes sure that the script doesn't try to create the account until a satisfactory name is found.

This PR fixes those issues.
